### PR TITLE
(refactor) concurrent hit-rate query

### DIFF
--- a/aisbench_test.py
+++ b/aisbench_test.py
@@ -2,6 +2,7 @@ import os, errno
 import argparse
 import re
 import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from config import *
 from generate_dataset import *
 from save_file import get_data, save_csv, save_log
@@ -135,21 +136,31 @@ def modify_aisbench_api(concurrency, output_len):
         os.path.join(WORK_PATH, "ais_bench/benchmark/configs/models/vllm_api/vllm_api_chat_temp.py")
     )
 
+def _fetch_pod_metrics(pod):
+    if pod.startswith('['):
+        # IPv6 格式: [ip]:port
+        ip = pod.split(']:')[0][1:]
+        port = pod.split(']:')[1]
+    elif pod.count(':') > 1:
+        # IPv6 格式无方括号: ip:port
+        ip, port = pod.rsplit(':', 1)
+    else:
+        # IPv4 格式: ip:port
+        ip, port = pod.split(":")
+    query_token, query_external = get_prefix_queries_total(ip, port)
+    hit_token, hit_external = get_prefix_hits_total(ip, port)
+    return pod, query_token, query_external, hit_token, hit_external
+
 def get_pod_metrics_info(pod_info):
-    query_tokens, query_tokens_external,hit_tokens,hit_tokens_external = {},{},{},{}
-    for pod in pod_info:
-        if pod.startswith('['):
-            # IPv6 格式: [ip]:port
-            ip = pod.split(']:')[0][1:]
-            port = pod.split(']:')[1]
-        elif pod.count(':') > 1:
-            # IPv6 格式无方括号: ip:port 
-            ip, port = pod.rsplit(':', 1)
-        else:
-            # IPv4 格式: ip:port
-            ip, port = pod.split(":")
-        query_tokens[pod],query_tokens_external[pod] = get_prefix_queries_total(ip,port)
-        hit_tokens[pod], hit_tokens_external[pod] = get_prefix_hits_total(ip,port)
+    query_tokens, query_tokens_external, hit_tokens, hit_tokens_external = {}, {}, {}, {}
+    with ThreadPoolExecutor(max_workers=len(pod_info)) as executor:
+        futures = [executor.submit(_fetch_pod_metrics, pod) for pod in pod_info]
+        for future in as_completed(futures):
+            pod, q_n, q_e, h_n, h_e = future.result()
+            query_tokens[pod] = q_n
+            query_tokens_external[pod] = q_e
+            hit_tokens[pod] = h_n
+            hit_tokens_external[pod] = h_e
     return query_tokens, query_tokens_external, hit_tokens, hit_tokens_external
 
 def cal_prefix_hit_info(query_tokens, query_tokens_external, hit_tokens, hit_tokens_external, query_tokens_new,

--- a/cal_prefix_hit_rate.py
+++ b/cal_prefix_hit_rate.py
@@ -1,24 +1,23 @@
-import subprocess
 import logging
 import re
 from datetime import datetime
-import os
+import requests
+
+def _fetch_metrics(ip_address, port):
+    """获取 /metrics 接口文本"""
+    url = f"http://{ip_address}:{port}/metrics"
+    resp = requests.get(url, proxies={"http": None, "https": None}, timeout=30)
+    resp.raise_for_status()
+    return resp.text
+
 
 def get_prefix_queries_total(ip_address, port):
     """
     获取查询token总数,返回{engine:tokens}
     """
     try:
-        # 构建并执行命令
-        url = f"http://{ip_address}:{port}/metrics"
-        command = f"unset http_proxy && unset https_proxy && sleep 3s && curl -s {url} | grep 'prefix_cache_queries_total' | grep 'model_name'"
-        # os.system(command)
-        result = subprocess.run(command, shell=True, capture_output=True, text=True, timeout=30)
-        
-        if result.returncode != 0 or not result.stdout.strip():
-            # print(f"未找到指标数据: {result.stderr}")
-            return {}, {}
-        lines = result.stdout.strip().split('\n')
+        text = _fetch_metrics(ip_address, port)
+        lines = [l for l in text.split('\n') if 'model_name' in l and 'prefix_cache_queries_total' in l]
         normal_stats = {}
         external_stats = {}
         
@@ -50,7 +49,6 @@ def get_prefix_queries_total(ip_address, port):
                 normal_stats[int(engine)] = value
         print(normal_stats, external_stats)
         return normal_stats, external_stats
-        
     except Exception as e:
         print(f"错误: {e}")
         return {}, {}
@@ -60,16 +58,8 @@ def get_prefix_hits_total(ip_address, port):
     获取命中token总数,返回{engine:tokens}
     """
     try:
-        # 构建并执行命令
-        url = f"http://{ip_address}:{port}/metrics"
-        command = f"unset http_proxy && unset https_proxy && sleep 3s && curl -s {url} | grep 'prefix_cache_hits_total' | grep 'model_name'"
-        # os.system(command)
-        
-        result = subprocess.run(command, shell=True, capture_output=True, text=True, timeout=30)
-        
-        if result.returncode != 0 or not result.stdout.strip():
-            return {}, {}
-        lines = result.stdout.strip().split('\n')
+        text = _fetch_metrics(ip_address, port)
+        lines = [l for l in text.split('\n') if 'model_name' in l and 'prefix_cache_hits_total' in l]
         normal_stats = {}
         external_stats = {}
         


### PR DESCRIPTION
**功能**：利用线程池加速/metrics请求，去掉sleep 3s的逻辑。在dp32的场景下，会引入64次/metrics请求。当前的sleep逻辑会引入180s的无意义等待。

**验证**：单机场景下验证，hbm_hit_rate结果完全一致。

**相关issue**：
https://github.com/rayn-zzz/aisbench_auto_tools_prefix/issues/16
https://github.com/rayn-zzz/aisbench_auto_tools_prefix/issues/14
